### PR TITLE
Fixed READ_MESSAGES not existing discord.js flag

### DIFF
--- a/helpers/database.js
+++ b/helpers/database.js
@@ -15,7 +15,7 @@ async function connectToDb(message) {
     moveerMessage.logger(message, 'Error')
     moveerMessage.sendMessage(
       message,
-      "Moveer cannot communicate with it's database. Since this is a admin command please create a text channel named moveeradmin and use that until my developer fixes this! He has been alerted but please poke him inside the support server! https://discord.gg/dTdH3gD"
+      "Moveer cannot communicate with its database. Since this is a admin command please create a text channel named moveeradmin and use that until my developer fixes this! He has been alerted but please poke him inside the support server! https://discord.gg/dTdH3gD"
     )
   }
 }

--- a/main.js
+++ b/main.js
@@ -84,7 +84,7 @@ client.on('guildCreate', async (guild) => {
       channel.type === 'text' &&
       defaultChannel === '' &&
       channel.permissionsFor(guild.me).has('SEND_MESSAGES') &&
-      channel.permissionsFor(guild.me).has('READ_MESSAGES')
+      channel.permissionsFor(guild.me).has('VIEW_CHANNEL')
     ) {
       defaultChannel = channel
     }


### PR DESCRIPTION
- changed the READ_MESSAGES flag inside main.js to VIEW_CHANNEL (having the same permissions) because that flag does not exist in the list of possible flags of discord.js numeric permissions; this is a possible cause of not sending a welcome message when joining a new guild (it gave the error "Invalid bitfield flag or number")
- typo (possessive "its")